### PR TITLE
moment function bug - changed import & updated "variant-call-format-parser"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5432,7 +5432,28 @@
       "version": "file:projects/hpv-viz",
       "requires": {
         "lodash": "^4.17.15",
-        "variant-call-format-parser": "^1.0.1"
+        "moment": "^2.25.1",
+        "variant-call-format-parser": "^1.0.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+        },
+        "moment": {
+          "version": "2.25.1",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.1.tgz",
+          "integrity": "sha512-nRKMf9wDS4Fkyd0C9LXh2FFXinD+iwbJ5p/lh3CHitW9kZbRbJ8hCruiadiIXZVbeAqKZzqcTvHnK3mRhFjb6w=="
+        },
+        "variant-call-format-parser": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/variant-call-format-parser/-/variant-call-format-parser-1.0.2.tgz",
+          "integrity": "sha512-+Zv1QYArAG4zVNc4TeRdibc/Vz/VaGEJhB3BGSwLUixZiZelkQ8VbUHSCYURP7ZVyE1jY/ycRBQl0KBtfHcE0g==",
+          "requires": {
+            "moment": "^2.25.1"
+          }
+        }
       }
     },
     "html-entities": {
@@ -6999,7 +7020,8 @@
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
@@ -7546,11 +7568,6 @@
       "requires": {
         "minimist": "^1.2.5"
       }
-    },
-    "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "move-concurrently": {
       "version": "1.0.1",
@@ -11774,14 +11791,6 @@
       "dev": true,
       "requires": {
         "builtins": "^1.0.3"
-      }
-    },
-    "variant-call-format-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/variant-call-format-parser/-/variant-call-format-parser-1.0.1.tgz",
-      "integrity": "sha512-+7Nq9SZY+JlaOS20EzaU7lYl7m8Wx3ffVxTvw4CytS1U1SfRiyWYMn6EZnuLLyFQq8aMRZb1E2AiU417mAoDwQ==",
-      "requires": {
-        "moment": "^2.24.0"
       }
     },
     "vary": {

--- a/projects/hpv-viz/package-lock.json
+++ b/projects/hpv-viz/package-lock.json
@@ -10,16 +10,16 @@
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "moment": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+      "version": "2.25.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.25.1.tgz",
+      "integrity": "sha512-nRKMf9wDS4Fkyd0C9LXh2FFXinD+iwbJ5p/lh3CHitW9kZbRbJ8hCruiadiIXZVbeAqKZzqcTvHnK3mRhFjb6w=="
     },
     "variant-call-format-parser": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/variant-call-format-parser/-/variant-call-format-parser-1.0.1.tgz",
-      "integrity": "sha512-+7Nq9SZY+JlaOS20EzaU7lYl7m8Wx3ffVxTvw4CytS1U1SfRiyWYMn6EZnuLLyFQq8aMRZb1E2AiU417mAoDwQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/variant-call-format-parser/-/variant-call-format-parser-1.0.2.tgz",
+      "integrity": "sha512-+Zv1QYArAG4zVNc4TeRdibc/Vz/VaGEJhB3BGSwLUixZiZelkQ8VbUHSCYURP7ZVyE1jY/ycRBQl0KBtfHcE0g==",
       "requires": {
-        "moment": "^2.24.0"
+        "moment": "^2.25.1"
       }
     }
   }

--- a/projects/hpv-viz/package.json
+++ b/projects/hpv-viz/package.json
@@ -6,11 +6,11 @@
   },
   "peerDependencies": {
     "@angular/common": "^6.0.0-rc.0 || ^6.0.0",
-    "@angular/core": "^6.0.0-rc.0 || ^6.0.0",
-    "moment": "^2.24.0"
+    "@angular/core": "^6.0.0-rc.0 || ^6.0.0"
   },
   "dependencies": {
     "lodash": "^4.17.15",
-    "variant-call-format-parser": "^1.0.1"
+    "moment": "^2.25.1",
+    "variant-call-format-parser": "^1.0.2"
   }
 }

--- a/projects/hpv-viz/src/lib/file-upload/file-upload.component.ts
+++ b/projects/hpv-viz/src/lib/file-upload/file-upload.component.ts
@@ -75,7 +75,11 @@ export class FileUploadComponent implements OnInit {
    * @param fileName
    */
   private getDate(result: any, fileName: string): Date {
-    let date = this.dateParserUtil.getDateFromFileName(fileName) || vcfParserService.extractDate(result);
+    let date = this.dateParserUtil.getDateFromFileName(fileName);
+    // Check for an invalid date
+    if (!date || isNaN(date.getTime())){
+      date = vcfParserService.extractDate(result);
+    }
     if (!date) {
       console.error(`Could not parse date from filename: ${fileName} or uploaded file. Using current date`);
       date = new Date();

--- a/projects/hpv-viz/src/lib/utils/date-parser.util.ts
+++ b/projects/hpv-viz/src/lib/utils/date-parser.util.ts
@@ -1,6 +1,14 @@
-import * as moment_ from 'moment';
-
-const moment = moment_;
+/**
+ * Question: Why not import "* as moment from moment""?
+ *
+ * Answer: This is a finicky import. After a moment update, this should work and not throw this
+ *  "hpv/projects/hpv-viz/node_modules/moment/moment"' has no default export." has no default export.
+ *  Apparently moment usually explodes a function, which would probably be done at runtime and not compile-time.
+ *  So just play around with this?
+ * Ref - https://stackoverflow.com/questions/35272832/systemjs-moment-is-not-a-function
+ */
+// @ts-ignore
+import moment from 'moment';
 
 export default class DateParserUtil {
   /**

--- a/projects/hpv-viz/src/test/mock-data/vcf-files/mock-vcfs.ts
+++ b/projects/hpv-viz/src/test/mock-data/vcf-files/mock-vcfs.ts
@@ -2,7 +2,7 @@
 export const P1_MOCK =
   `##fileformat=VCFv4.1
 ##fileDate=20110213
-##fileUTCtime=2011-02-13T10:38:12
+##fileUTCtime=2011-02-13T00:00:00
 ##source="MOCK"
 ##parametersName="MOCK"
 ##parametersDetails="MOCK"


### PR DESCRIPTION
Received error "moment is not a function". Seems like sometimes there is some issue exploding the imported function on import. This makes it a non-runtime error, but potentially an error at compile-time (Ref - https://stackoverflow.com/questions/35272832/systemjs-moment-is-not-a-function)

Fixes:
* Updated "variant-call-format-parser" to "1.0.2"
* Updated moment
* Modified moment import method

